### PR TITLE
OAuth now required for all endpoints

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Provides functions to make Twitch.tv API calls.
 License: GPL-3
 Depends: R (>= 3.4.0)
 Imports: httr, purrr, dplyr, magrittr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 URL: https://github.com/Freguglia/rTwitchAPI
 BugReports: https://github.com/Freguglia/rTwitchAPI/issues
 Encoding: UTF-8

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -3,11 +3,25 @@
 #' Sets up your Client-ID or forgets it.
 #' @name authentication
 #' @param client_id your client-ID.
+#' @param client_secret your client-secret.
 #' @references https://dev.twitch.tv/docs/authentication/
 #' @details If, for some reason, you need to change what client-ID you're making calls with, use use \code{\link{twitch_auth_forget}} and then reuse this function to set the new client-ID. Check the link in references to understand what is a client-ID, how it works and how to get one.
 #' @export
-twitch_auth = function(client_id){
-  httr::set_config(httr::add_headers('Client-ID' = client_id))
+twitch_auth = function(){
+  
+  client_id <- Sys.getenv("TWITCH_CLIENT_ID")
+  client_secret <- Sys.getenv("TWITCH_CLIENT_SECRET")
+  
+  if (client_id == "" | client_secret == ""){
+    stop("Please add TWITCH_CLIENT_ID and TWITCH_CLIENT_SECRET to your environment variables (see documentation for reference).")
+  }
+  
+  o <- httr::POST("https://id.twitch.tv/oauth2/token", 
+            query = query_list(client_id=client_id, 
+                               client_secret = client_secret,
+                               grant_type="client_credentials")) %>% content()
+  
+  httr::set_config(httr::add_headers('Client-ID' = client_id, Authorization=glue::glue("Bearer {o$access_token}")))
 }
 
 #' @rdname authentication

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -1,9 +1,7 @@
 #' Authentication
 #' 
-#' Sets up your Client-ID or forgets it.
+#' Set up your Client-ID and Secret or forget them.
 #' @name authentication
-#' @param client_id your client-ID.
-#' @param client_secret your client-secret.
 #' @references https://dev.twitch.tv/docs/authentication/
 #' @details If, for some reason, you need to change what client-ID you're making calls with, use use \code{\link{twitch_auth_forget}} and then reuse this function to set the new client-ID. Check the link in references to understand what is a client-ID, how it works and how to get one.
 #' @export

--- a/R/authentication.R
+++ b/R/authentication.R
@@ -21,7 +21,7 @@ twitch_auth = function(){
                                client_secret = client_secret,
                                grant_type="client_credentials")) %>% content()
   
-  httr::set_config(httr::add_headers('Client-ID' = client_id, Authorization=glue::glue("Bearer {o$access_token}")))
+  httr::set_config(httr::add_headers('Client-ID' = client_id, Authorization=paste0("Bearer ",o$access_token)))
 }
 
 #' @rdname authentication

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,17 +42,31 @@ devtools::install_github("Freguglia/rTwitchAPI")
 
 As most API's, Twitch API requires authentication for some types of calls, in the form of a **Client-ID** and/or an **Oauth token**. You can setup your Client-ID with the `twitch_auth()` function. For more information access on Client-ID and how to register your app, read [this link](https://dev.twitch.tv/dashboard/apps/create).
 
+**Define your Client-ID and Client-Secret variable.**
+
+In order to add your Client-ID and Client-Secret to your environment file, you can use the function `edit_r_environ()` from the [`usethis` package](https://usethis.r-lib.org/).
+
+```{r, eval = F}
+usethis::edit_r_environ()
+```
+
+
+This will open your .Renviron file in your text editor. Now, you can add the following line to it:
+
+```{r, eval = F}
+TWITCH_CLIENT_ID=YOUR_CLIENT_ID
+TWITCH_CLIENT_SECRET=YOUR_CLIENT_SECRET
+```
+
+Save the file and restart R for the changes to take effect.
 
 ## Example
 
 ```{r}
 library(rTwitchAPI)
-# Reading the Client-ID from a file for the example, but you can assign directly
-# my_client_id <- "YOUR_CLIENT_ID"
-my_client_id <- readChar("~/.twitch_auth", 30)
 
 # Setup authentication
-twitch_auth(my_client_id)
+twitch_auth()
 
 # An example request to the streams endpoint
 streams_live <- get_streams(first = 15, language = "en")

--- a/README.md
+++ b/README.md
@@ -54,40 +54,56 @@ setup your Client-ID with the `twitch_auth()` function. For more
 information access on Client-ID and how to register your app, read [this
 link](https://dev.twitch.tv/dashboard/apps/create).
 
+**Define your Client-ID and Client-Secret variable.**
+
+In order to add your Client-ID and Client-Secret to your environment
+file, you can use the function `edit_r_environ()` from the [`usethis`
+package](https://usethis.r-lib.org/).
+
+``` r
+usethis::edit_r_environ()
+```
+
+This will open your .Renviron file in your text editor. Now, you can add
+the following line to it:
+
+``` r
+TWITCH_CLIENT_ID=YOUR_CLIENT_ID
+TWITCH_CLIENT_SECRET=YOUR_CLIENT_SECRET
+```
+
+Save the file and restart R for the changes to take effect.
+
 ## Example
 
 ``` r
 library(rTwitchAPI)
-# Reading the Client-ID from a file for the example, but you can assign directly
-# my_client_id <- "YOUR_CLIENT_ID"
-my_client_id <- readChar("~/.twitch_auth", 30)
 
 # Setup authentication
-twitch_auth(my_client_id)
+twitch_auth()
 
 # An example request to the streams endpoint
 streams_live <- get_streams(first = 15, language = "en")
 streams_live$data
 #> # A tibble: 15 x 11
-#>    id    user_id user_name game_id type  title viewer_count started_at
-#>    <chr> <chr>   <chr>     <chr>   <chr> <chr>        <int> <chr>     
-#>  1 3563… 262614… Asmongold 18122   live  ONYX…        77381 2019-09-1…
-#>  2 3563… 173375… DrDisres… 512710  live  Mode…        33365 2019-09-1…
-#>  3 3563… 266102… CohhCarn… 491318  live  Bord…        21189 2019-09-1…
-#>  4 3563… 710929… xQcOW     509658  live  xqcT…        19432 2019-09-1…
-#>  5 3563… 725508… ROSHTEIN  498566  live  "🔥 G…        17731 2019-09-1…
-#>  6 3563… 409728… AdmiralB… 491318  live  I lo…        17299 2019-09-1…
-#>  7 3563… 155648… NICKMERCS 33214   live  2v2 …        16333 2019-09-1…
-#>  8 3563… 444246… NickEh30  33214   live  Frid…        13876 2019-09-1…
-#>  9 3563… 367690… TimTheTa… 18122   live  hey …        13570 2019-09-1…
-#> 10 3563… 10406   Karma     512710  live  The …        11134 2019-09-1…
-#> 11 3563… 609784… dogdog    513143  live  Dona…        10572 2019-09-1…
-#> 12 3563… 444455… pokimane  509658  live  we a…         9846 2019-09-1…
-#> 13 3563… 121203… Yassuo    21779   live  "Rai…         9527 2019-09-1…
-#> 14 3563… 360292… Riot Gam… 21779   live  EU M…         8916 2019-09-1…
-#> 15 3563… 250094… LexVeldh… 488190  live  "$52…         7909 2019-09-1…
-#> # … with 3 more variables: language <chr>, thumbnail_url <chr>,
-#> #   tag_ids <list>
+#>    id    user_id user_name game_id type  title viewer_count started_at language
+#>    <chr> <chr>   <chr>     <chr>   <chr> <chr>        <int> <chr>      <chr>   
+#>  1 1900~ 228592~ DreamHac~ 32399   live  "LIV~        60862 2020-06-0~ en      
+#>  2 3857~ 7601562 Chess     743     live  "Che~        52289 2020-06-0~ en      
+#>  3 3857~ 262614~ Asmongold 18122   live  "SHA~        39309 2020-06-0~ en      
+#>  4 3857~ 504976~ PardonMy~ 271198  live  "DUG~        30313 2020-06-0~ en      
+#>  5 3857~ 173375~ DrDisres~ 512710  live  "Gam~        30263 2020-06-0~ en      
+#>  6 3857~ 231613~ LIRIK     516867  live  "HAL~        23891 2020-06-0~ en      
+#>  7 3857~ 444455~ pokimane  27471   live  "cha~        21049 2020-06-0~ en      
+#>  8 1903~ 198182~ MrSavage  33214   live  "Tri~        19693 2020-06-0~ en      
+#>  9 3857~ 1423946 Gernader~ 497057  live  "New~        19236 2020-06-0~ en      
+#> 10 3857~ 155648~ NICKMERCS 512710  live  "MFA~        17108 2020-06-0~ en      
+#> 11 3857~ 520918~ Castro_1~ 32982   live  "tox~        16638 2020-06-0~ en      
+#> 12 3857~ 106013~ Pestily   491931  live  "Dro~        16546 2020-06-0~ en      
+#> 13 3857~ 269911~ Hiko      516575  live  "100~        16401 2020-06-0~ en      
+#> 14 3857~ 297959~ nl_Kripp  138585  live  "NEW~        15389 2020-06-0~ en      
+#> 15 3857~ 514960~ loltyler1 21779   live  "oh ~        15283 2020-06-0~ en      
+#> # ... with 2 more variables: thumbnail_url <chr>, tag_ids <list>
 ```
 
 ## Contributions

--- a/man/authentication.Rd
+++ b/man/authentication.Rd
@@ -6,17 +6,12 @@
 \alias{twitch_auth_forget}
 \title{Authentication}
 \usage{
-twitch_auth(client_id, client_secret)
+twitch_auth()
 
 twitch_auth_forget()
 }
-\arguments{
-\item{client_id}{your client-ID.}
-
-\item{client_secret}{your client-secret.}
-}
 \description{
-Sets up your Client-ID or forgets it.
+Set up your Client-ID and Secret or forget them.
 }
 \details{
 If, for some reason, you need to change what client-ID you're making calls with, use use \code{\link{twitch_auth_forget}} and then reuse this function to set the new client-ID. Check the link in references to understand what is a client-ID, how it works and how to get one.

--- a/man/authentication.Rd
+++ b/man/authentication.Rd
@@ -6,12 +6,14 @@
 \alias{twitch_auth_forget}
 \title{Authentication}
 \usage{
-twitch_auth(client_id)
+twitch_auth(client_id, client_secret)
 
 twitch_auth_forget()
 }
 \arguments{
 \item{client_id}{your client-ID.}
+
+\item{client_secret}{your client-secret.}
 }
 \description{
 Sets up your Client-ID or forgets it.

--- a/man/get_streams.Rd
+++ b/man/get_streams.Rd
@@ -5,9 +5,17 @@
 \title{Get Streams
 Gets information about active streams.}
 \usage{
-get_streams(first = 20, after = NULL, before = NULL,
-  community_id = NULL, game_id = NULL, language = NULL,
-  type = NULL, user_id = NULL, user_login = NULL)
+get_streams(
+  first = 20,
+  after = NULL,
+  before = NULL,
+  community_id = NULL,
+  game_id = NULL,
+  language = NULL,
+  type = NULL,
+  user_id = NULL,
+  user_login = NULL
+)
 }
 \arguments{
 \item{first}{Maximum number of objects to return. Maximum: 100. Default: 20.}

--- a/man/get_users_follows.Rd
+++ b/man/get_users_follows.Rd
@@ -4,8 +4,13 @@
 \alias{get_users_follows}
 \title{Get Users Follows}
 \usage{
-get_users_follows(from_id = NULL, to_id = NULL, first = 20,
-  after = NULL, before = NULL)
+get_users_follows(
+  from_id = NULL,
+  to_id = NULL,
+  first = 20,
+  after = NULL,
+  before = NULL
+)
 }
 \arguments{
 \item{from_id}{User ID. The request returns information about users who are being followed by the from_id user.}


### PR DESCRIPTION
Hi! Thanks for the R package! I will have to use Twitch API and was happy to discover that there is an R implementation. Unfortunately, the current version is out-of-date since all API endpoints now require OAuth.

See here:
[https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916](https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916
)

I also made an update to how the client ID and secret are passed to `twitch_auth` since directly specifying such sensitive variables is problematic. Let me know if this works for you!

I am happy to work on it some more as I continue to use the API. So maybe you'll see another pull request or two in the next few days :) 